### PR TITLE
Fix: Remove useless hack.

### DIFF
--- a/lib/linked_in/mash.rb
+++ b/lib/linked_in/mash.rb
@@ -35,34 +35,5 @@ module LinkedIn
     def contains_date_fields?
       self.year? && self.month? && self.day?
     end
-
-    # overload the convert_key mash method so that the LinkedIn
-    # keys are made a little more ruby-ish
-    def convert_key(key)
-      case key.to_s
-      when '_key'
-        'id'
-      when '_total'
-        'total'
-      when 'values'
-        'all'
-      when 'numResults'
-        'total_results'
-      else
-        underscore(key)
-      end
-    end
-
-    # borrowed from ActiveSupport
-    # no need require an entire lib when we only need one method
-    def underscore(camel_cased_word)
-      word = camel_cased_word.to_s.dup
-      word.gsub!(/::/, '/')
-      word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-      word.tr!("-", "_")
-      word.downcase!
-      word
-    end
   end
 end


### PR DESCRIPTION
Remove an useless hack. I run the project specs without it and it works properly.

The issue with this hack is that it would convert this

```
dig('elements', -1)
```

into this

```
dig('elements', '_1')
```
