### PR TITLE
Better: hide headers and bodies in logs. RD-23922

### DIFF
--- a/lib/linked_in/connection.rb
+++ b/lib/linked_in/connection.rb
@@ -27,7 +27,7 @@ module LinkedIn
       # the same param to certain endpoints (like the search API).
       self.options.params_encoder = LinkedIn::DoNotEscapeEncoder
 
-      self.response :logger, LinkedIn.logger
+      self.response :logger, LinkedIn.logger, { headers: false, bodies: false }
 
       self.response :linkedin_raise_error
     end


### PR DESCRIPTION
Hide headers and bodies from logs keeping only the request and response status