### PR TITLE
Used versioned apis instead of v2

### DIFF
--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -71,7 +71,7 @@ module LinkedIn
       # https://docs.microsoft.com/fr-fr/linkedin/shared/authentication/client-credentials-flow?context=linkedin%2Fcontext&view=li-lms-2022-07#step-3-make-api-requests
       {
         'Connection' => 'Keep-Alive',
-        'LinkedIn-Version' => '202206',
+        'LinkedIn-Version' => LinkedIn.config.api_version,
         'Authorization' => "Bearer #{@access_token.token}"
       }
     end

--- a/lib/linked_in/configuration.rb
+++ b/lib/linked_in/configuration.rb
@@ -32,8 +32,8 @@ module LinkedIn
     alias_method :secret_key, :client_secret
 
     def initialize
-      @api = "https://api.linkedin.com"
-      @api_version = "/v2"
+      @api = "https://api.linkedin.com/rest"
+      @api_version = "202206"
       @site = "https://www.linkedin.com"
       @token_url = "/oauth/v2/accessToken"
       @authorize_url = "/uas/oauth2/authorization"

--- a/lib/linked_in/connection.rb
+++ b/lib/linked_in/connection.rb
@@ -37,7 +37,7 @@ module LinkedIn
 
 
     def default_url
-      LinkedIn.config.api + LinkedIn.config.api_version
+      LinkedIn.config.api
     end
   end
 end


### PR DESCRIPTION
LinkedIn is phasing out unversionned apis (v2) lets make the switch to versionned apis